### PR TITLE
Fix session lookup

### DIFF
--- a/backend/src/backend/db_functions/user_sessions/create_user_session.py
+++ b/backend/src/backend/db_functions/user_sessions/create_user_session.py
@@ -35,7 +35,7 @@ async def create_user_session(
             user=user,
             ip_address=ip_address,
             user_agent=user_agent,
-            token=token,
+            session_token=token,
             expires_at=expires_at,
             is_active=True,
         )

--- a/backend/src/backend/db_functions/user_sessions/get_user_session_by_token.py
+++ b/backend/src/backend/db_functions/user_sessions/get_user_session_by_token.py
@@ -10,7 +10,7 @@ from backend.schemas.user import UserSessionSchema
 async def get_user_session_by_token(token: str) -> Optional[UserSessionSchema]:
     # Find the session by token
     query = UserSession.filter(session_token=token, is_active=True)
-    session = await query.first().prefetch_related("user")
+    session = await query.prefetch_related("user").first()
 
     if not session:
         return None


### PR DESCRIPTION
## Summary
- fix prefetch order bug in `get_user_session_by_token`
- fix wrong field name in `create_user_session`

## Testing
- `./scripts/ruff-format.sh`
- `./scripts/ruff-check.sh`
- `./scripts/mypy.sh`
- `./scripts/pyright.sh`
- `./scripts/pytest.sh`

------
https://chatgpt.com/codex/tasks/task_e_684b7f0e299c8323adcac0ba64f6579f