### PR TITLE
Fix gunicorn workers

### DIFF
--- a/backend/gunicorn.conf.py
+++ b/backend/gunicorn.conf.py
@@ -12,7 +12,7 @@ bind = os.getenv("GUNICORN_BIND", "0.0.0.0:8000")
 backlog = 2048
 
 # Worker processes
-workers = os.getenv("GUNICORN_WORKERS", multiprocessing.cpu_count() * 2 + 1)
+workers = int(os.getenv("GUNICORN_WORKERS", multiprocessing.cpu_count() * 2 + 1))
 worker_class = "uvicorn.workers.UvicornWorker"
 worker_connections = 1000
 timeout = 30


### PR DESCRIPTION
## Summary
- cast gunicorn `workers` to int from the environment
- run ruff formatting
- run backend tests

## Testing
- `./scripts/ruff-format.sh`
- `./scripts/pytest.sh`


------
https://chatgpt.com/codex/tasks/task_e_684b867a0b9c8323b21c0ece7650043b