### PR TITLE
Fix trailing slashes on debug and moderation routes

### DIFF
--- a/backend/src/backend/routes/admin/moderation/pending_posts.py
+++ b/backend/src/backend/routes/admin/moderation/pending_posts.py
@@ -39,7 +39,7 @@ async def list_all_pending_posts(
     return await list_pending_posts(limit=limit, offset=offset)
 
 
-@router.post("/{pending_post_id}/approve")
+@router.post("/{pending_post_id}/approve/")
 async def approve_pending_post(
     pending_post_id: UUID,
     background_tasks: BackgroundTasks,
@@ -79,7 +79,7 @@ async def approve_pending_post(
     }
 
 
-@router.post("/{pending_post_id}/reject")
+@router.post("/{pending_post_id}/reject/")
 async def reject_pending_post_route(
     pending_post_id: UUID,
     background_tasks: BackgroundTasks,

--- a/backend/src/backend/routes/api/topics/debug_topics.py
+++ b/backend/src/backend/routes/api/topics/debug_topics.py
@@ -10,7 +10,7 @@ from backend.schemas.topic import TopicList
 router = APIRouter()
 
 
-@router.get("/debug", response_model=TopicList)
+@router.get("/debug/", response_model=TopicList)
 async def debug_topics() -> TopicList:
     """
     Debug endpoint to get all topics with their descriptions and tags.

--- a/backend/src/backend/routes/topics/debug_topics.py
+++ b/backend/src/backend/routes/topics/debug_topics.py
@@ -10,7 +10,7 @@ from backend.schemas.topic import TopicList
 router = APIRouter()
 
 
-@router.get("/debug", response_model=TopicList)
+@router.get("/debug/", response_model=TopicList)
 async def debug_topics() -> TopicList:
     """
     Debug endpoint to get all topics with their descriptions and tags.


### PR DESCRIPTION
## Summary
- update debug endpoints to have trailing slashes
- update admin moderation pending post routes to have trailing slashes
- ensure format and tests pass

## Testing
- `./scripts/ruff-format.sh`
- `./scripts/pytest.sh`


------
https://chatgpt.com/codex/tasks/task_e_684b86725388832387516afa0867325e