### PR TITLE
Add tests for additional database models

### DIFF
--- a/backend/tests/db/models/test_pending_post.py
+++ b/backend/tests/db/models/test_pending_post.py
@@ -1,0 +1,41 @@
+from unittest import mock
+
+import pytest
+
+from backend.db.models.pending_post import PendingPost
+from backend.db.models.topic import Topic
+from backend.db.models.user import User
+
+
+@pytest.mark.asyncio
+async def test_pending_post_create() -> None:
+    # Arrange
+    content = "Pending content"
+    mock_author = mock.AsyncMock(spec=User)
+    mock_topic = mock.AsyncMock(spec=Topic)
+
+    # Mock the PendingPost.create method
+    with mock.patch.object(PendingPost, "create", new=mock.AsyncMock()) as mock_create:
+        # Act
+        await PendingPost.create(
+            content=content,
+            author=mock_author,
+            topic=mock_topic,
+        )
+
+        # Assert
+        mock_create.assert_called_once_with(
+            content=content,
+            author=mock_author,
+            topic=mock_topic,
+        )
+
+
+@pytest.mark.asyncio
+async def test_pending_post_fields() -> None:
+    # Arrange
+    post = PendingPost(content="Example")
+
+    # Assert
+    assert post.content == "Example"
+    assert post.parent_post_id is None

--- a/backend/tests/db/models/test_rejected_post.py
+++ b/backend/tests/db/models/test_rejected_post.py
@@ -1,0 +1,45 @@
+from unittest import mock
+
+import pytest
+
+from backend.db.models.rejected_post import RejectedPost
+from backend.db.models.topic import Topic
+from backend.db.models.user import User
+
+
+@pytest.mark.asyncio
+async def test_rejected_post_create() -> None:
+    # Arrange
+    content = "Rejected"
+    reason = "Spam"
+    mock_author = mock.AsyncMock(spec=User)
+    mock_topic = mock.AsyncMock(spec=Topic)
+
+    # Mock the RejectedPost.create method
+    with mock.patch.object(RejectedPost, "create", new=mock.AsyncMock()) as mock_create:
+        # Act
+        await RejectedPost.create(
+            content=content,
+            author=mock_author,
+            topic=mock_topic,
+            moderation_reason=reason,
+        )
+
+        # Assert
+        mock_create.assert_called_once_with(
+            content=content,
+            author=mock_author,
+            topic=mock_topic,
+            moderation_reason=reason,
+        )
+
+
+@pytest.mark.asyncio
+async def test_rejected_post_fields() -> None:
+    # Arrange
+    post = RejectedPost(content="Text", moderation_reason="Spam")
+
+    # Assert
+    assert post.content == "Text"
+    assert post.moderation_reason == "Spam"
+    assert post.parent_post_id is None

--- a/backend/tests/db/models/test_user.py
+++ b/backend/tests/db/models/test_user.py
@@ -1,0 +1,46 @@
+from unittest import mock
+
+import pytest
+
+from backend.db.models.user import User
+from backend.db.models.user import UserRole
+
+
+@pytest.mark.asyncio
+async def test_user_create() -> None:
+    # Arrange
+    email = "user@example.com"
+    display_name = "Tester"
+    password_hash = "hash"
+
+    # Mock the User.create method
+    with mock.patch.object(User, "create", new=mock.AsyncMock()) as mock_create:
+        # Act
+        await User.create(
+            email=email,
+            password_hash=password_hash,
+            display_name=display_name,
+        )
+
+        # Assert
+        mock_create.assert_called_once_with(
+            email=email,
+            password_hash=password_hash,
+            display_name=display_name,
+        )
+
+
+@pytest.mark.asyncio
+async def test_user_defaults() -> None:
+    # Arrange
+    user = User(email="a@b.com", password_hash="h", display_name="n")
+
+    # Assert
+    assert user.is_verified is False
+    assert user.failed_login_attempts == 0
+    assert user.role == UserRole.USER
+    assert user.is_locked is False
+
+    email_field = User._meta.fields_map.get("email")
+    assert email_field is not None
+    assert email_field.unique is True

--- a/backend/tests/db/models/test_user_event.py
+++ b/backend/tests/db/models/test_user_event.py
@@ -1,0 +1,45 @@
+from unittest import mock
+
+import pytest
+
+from backend.db.models.user import User
+from backend.db.models.user_event import UserEvent
+
+
+@pytest.mark.asyncio
+async def test_user_event_create() -> None:
+    # Arrange
+    mock_user = mock.AsyncMock(spec=User)
+
+    # Mock the UserEvent.create method
+    with mock.patch.object(UserEvent, "create", new=mock.AsyncMock()) as mock_create:
+        # Act
+        await UserEvent.create(
+            user=mock_user,
+            event_type="login",
+            ip_address="127.0.0.1",
+        )
+
+        # Assert
+        mock_create.assert_called_once_with(
+            user=mock_user,
+            event_type="login",
+            ip_address="127.0.0.1",
+        )
+
+
+@pytest.mark.asyncio
+async def test_user_event_fields() -> None:
+    # Arrange
+    event = UserEvent(event_type="logout")
+
+    # Assert
+    assert event.event_type == "logout"
+    assert event.ip_address is None
+    assert event.user_agent is None
+    assert event.resource_type is None
+    assert event.resource_id is None
+    assert event.metadata is None
+
+    event_type_field = UserEvent._meta.fields_map.get("event_type")
+    assert event_type_field.max_length == 50


### PR DESCRIPTION
## Summary
- add coverage for pending_post, rejected_post, user, and user_event models
- update comments in tests for clarity

## Testing
- `bash scripts/pre-commit.sh`
- `bash scripts/pytest.sh`

------
https://chatgpt.com/codex/tasks/task_e_684c6292ebc883239addda0fabe60022